### PR TITLE
Allow multiple connections to file databases

### DIFF
--- a/Sources/CFrontbaseSupport/Support.c
+++ b/Sources/CFrontbaseSupport/Support.c
@@ -18,7 +18,7 @@ FBSConnection fbsConnectDatabaseOnHost (const char* databaseName,
 										const char* password,
                                         const char* defaultSessionName,
                                         const char* operatingSystemUser,
-										const char** errorMessage) {
+										char** errorMessage) {
 	const char* localError = NULL;
 	char digest[1000];
 	FBCDatabaseConnection* connection = fbcdcConnectToDatabaseRM (databaseName, hostName, _fbsDigestPassword ("_SYSTEM", databasePassword, digest), &localError);
@@ -51,7 +51,7 @@ FBSConnection fbsConnectDatabaseOnHost (const char* databaseName,
 	} else {
         fbcdcSetFormatResult (connection, 0);
 
-        const char* timeZoneMessage = NULL;
+        char* timeZoneMessage = NULL;
 
         FBSResult result = fbsExecuteSQL (connection, "SET TIME ZONE 'UTC';", 1, &timeZoneMessage);
 
@@ -81,7 +81,7 @@ FBSConnection fbsConnectDatabaseOnPort (const char* hostName,
 										const char* password,
                                         const char* defaultSessionName,
                                         const char* operatingSystemUser,
-										const char** errorMessage) {
+										char** errorMessage) {
 	const char* localError = NULL;
 	char digest[1000];
 	FBCDatabaseConnection* connection = fbcdcConnectToDatabaseUsingPortRM (hostName, port, _fbsDigestPassword ("_SYSTEM", databasePassword, digest), &localError);
@@ -114,7 +114,7 @@ FBSConnection fbsConnectDatabaseOnPort (const char* hostName,
 	} else {
         fbcdcSetFormatResult (connection, 0);
 
-        const char* timeZoneMessage = NULL;
+        char* timeZoneMessage = NULL;
 
         FBSResult result = fbsExecuteSQL (connection, "SET TIME ZONE 'UTC';", 1, &timeZoneMessage);
 
@@ -144,7 +144,7 @@ FBSConnection fbsConnectDatabaseAtPath (const char* databaseName,
 										const char* password,
                                         const char* defaultSessionName,
                                         const char* operatingSystemUser,
-										const char** errorMessage) {
+										char** errorMessage) {
 	const char* localError = NULL;
 	char digest[1000];
 	char url[1025];
@@ -174,7 +174,7 @@ FBSConnection fbsConnectDatabaseAtPath (const char* databaseName,
 
 	fbcdcSetFormatResult (connection, 0);
 
-	const char* timeZoneMessage = NULL;
+	char* timeZoneMessage = NULL;
 
 	FBSResult result = fbsExecuteSQL (connection, "SET TIME ZONE 'UTC';", 1, &timeZoneMessage);
 
@@ -238,7 +238,7 @@ const char* fbsErrorMessage (FBSConnection connection) {
 FBSResult fbsExecuteSQL (FBSConnection connection,
                          const char* sql,
                          bool autoCommit,
-                         const char** errorMessage) {
+                         char** errorMessage) {
 	FBCDatabaseConnection* databaseConnection = connection;
     FBCMetaData* metadata = fbcdcExecuteSQL (databaseConnection, (char*)sql, (unsigned int)strlen (sql), autoCommit ? FBCDCCommit : 0);
 

--- a/Sources/CFrontbaseSupport/Support.c
+++ b/Sources/CFrontbaseSupport/Support.c
@@ -4,6 +4,9 @@
 #include <stdlib.h> // for malloc()
 
 // Internal
+static char *_fbcCopyAllMessages(FBCMetaData*);
+static char *_fbcCopyError(const char *);
+
 const char* digestPassword (const char* username, const char* password, char* digest) {
 	if (password == NULL) {
 		return NULL;
@@ -24,7 +27,7 @@ static char *_fbcCopyAllMessages(FBCMetaData *md) {
 	char *copy = NULL;
 
 	if ((allMessages = fbcemdAllErrorMessages(emd)) != NULL) {
-		copy = (char *)malloc(strlen(allMessages));
+        copy = _fbcCopyError(allMessages);
 		fbcemdReleaseMessage(allMessages);
 	}
 

--- a/Sources/CFrontbaseSupport/Support.c
+++ b/Sources/CFrontbaseSupport/Support.c
@@ -4,8 +4,8 @@
 #include <stdlib.h> // for malloc()
 
 // Internal
-static char *_fbcCopyAllMessages(FBCMetaData*);
-static char *_fbcCopyError(const char *);
+static char *_fbsCopyAllMessages (FBCMetaData*);
+static char *_fbsCopyError(const char *);
 
 const char* digestPassword (const char* username, const char* password, char* digest) {
 	if (password == NULL) {
@@ -15,33 +15,33 @@ const char* digestPassword (const char* username, const char* password, char* di
 	}
 }
 
-/// Return a copy of all error messages associated with `md`, or `NULL` if there are none.
+/// Return a copy of all error messages associated with `metadata`, or `NULL` if there are none.
 /// The caller must free the returned string.
 /// The rationale for this function is this note from the meastro:
 ///   "You should always use fbcemdReleaseMessage on the result from fbcemdAllErrorMessages"
-static char *_fbcCopyAllMessages(FBCMetaData *md) {
-	if (!fbcmdErrorsFound(md)) return NULL;
+static char *_fbsCopyAllMessages (FBCMetaData* metadata) {
+	if (!fbcmdErrorsFound (metadata)) return NULL;
 
-	FBCErrorMetaData *emd = fbcmdErrorMetaData(md);
-	char *allMessages = NULL;
-	char *copy = NULL;
+	FBCErrorMetaData* emd = fbcmdErrorMetaData (metadata);
+	char* allMessages = NULL;
+	char* copy = NULL;
 
-	if ((allMessages = fbcemdAllErrorMessages(emd)) != NULL) {
-        copy = _fbcCopyError(allMessages);
-		fbcemdReleaseMessage(allMessages);
+	if ((allMessages = fbcemdAllErrorMessages (emd)) != NULL) {
+		copy = _fbsCopyError (allMessages);
+		fbcemdReleaseMessage (allMessages);
 	}
 
-	fbcemdRelease(emd);
+	fbcemdRelease (emd);
 
 	return copy;
 }
 
 /// Return a copy of the NULL terminated string `msg`.
 /// The caller is responsible for freeing the copy.
-static char *_fbcCopyError(const char *msg) {
-	unsigned long len = strlen(msg);
-	char *copy = (char *)malloc(len + 1);
-	memcpy(copy, msg, len);
+static char* _fbsCopyError(const char* msg) {
+	unsigned long len = strlen (msg);
+	char* copy = (char*) malloc (len + 1);
+	memcpy (copy, msg, len);
 	copy[len] = 0;
 	return copy;
 }
@@ -193,28 +193,28 @@ FBSConnection fbsConnectDatabaseAtPath (const char* databaseName,
 	char digest[1000];
 	char url[1025];
 
-	int n = snprintf(url, 1025, "file://%s", filePath);
+	int n = snprintf (url, 1025, "file://%s", filePath);
 	if (n >= 1025) {
 		if (errorMessage != NULL) {
-			*errorMessage = _fbcCopyError("path too long");
+			*errorMessage = _fbsCopyError ("path too long");
 		}
 		return NULL;
 	}
 
-	FBCMetaData *md = fbcdcConnectToURL(url, digestPassword ("_SYSTEM", databasePassword, digest), username, digestPassword (username, password, digest),defaultSessionName);
+	FBCMetaData* metadata = fbcdcConnectToURL(url, digestPassword ("_SYSTEM", databasePassword, digest), username, digestPassword (username, password, digest),defaultSessionName);
 
-	if (fbcmdErrorsFound(md)) {
+	if (fbcmdErrorsFound(metadata)) {
 		if (errorMessage != NULL) {
-			*errorMessage = _fbcCopyAllMessages(md);
+			*errorMessage = _fbsCopyAllMessages (metadata);
 		}
 
-		fbcmdRelease(md);
+		fbcmdRelease (metadata);
 		return NULL;
 	}
 
-	FBCDatabaseConnection *connection = fbcdcRetain(fbcmdDatabaseConnection(md));
-	fbcmdRelease(md);
-	md = NULL;
+	FBCDatabaseConnection* connection = fbcdcRetain (fbcmdDatabaseConnection (metadata));
+	fbcmdRelease (metadata);
+	metadata = NULL;
 
 	fbcdcSetFormatResult (connection, 0);
 
@@ -288,7 +288,7 @@ FBSResult fbsExecuteSQL (FBSConnection connection,
 
 	if (fbcmdErrorsFound (metadata)) {
 		if (errorMessage != NULL) {
-			*errorMessage = _fbcCopyAllMessages(metadata);
+			*errorMessage = _fbsCopyAllMessages (metadata);
 		}
 
 		fbcmdRelease (metadata);

--- a/Sources/CFrontbaseSupport/Support.c
+++ b/Sources/CFrontbaseSupport/Support.c
@@ -23,11 +23,10 @@ FBSConnection fbsConnectDatabaseOnHost (const char* databaseName,
 	char digest[1000];
 	FBCDatabaseConnection* connection = fbcdcConnectToDatabaseRM (databaseName, hostName, _fbsDigestPassword ("_SYSTEM", databasePassword, digest), &localError);
 	FBCMetaData* session;
-	FBCErrorMetaData* errorMetaData;
 
 	if (connection == NULL) {
 		if (errorMessage != NULL) {
-			*errorMessage = localError;
+			*errorMessage = _fbsCopyError(localError);
 		}
 		return NULL;
 	}
@@ -41,9 +40,7 @@ FBSConnection fbsConnectDatabaseOnHost (const char* databaseName,
 		return NULL;
 	} else if (fbcmdErrorsFound (session)) {
 		if (errorMessage != NULL) {
-			errorMetaData = fbcmdErrorMetaData (session);
-			*errorMessage = fbcemdAllErrorMessages (errorMetaData);
-			fbcemdRelease (errorMetaData);
+			*errorMessage = _fbsCopyAllMessages (session);
 		}
 
 		fbcmdRelease (session);
@@ -89,11 +86,10 @@ FBSConnection fbsConnectDatabaseOnPort (const char* hostName,
 	char digest[1000];
 	FBCDatabaseConnection* connection = fbcdcConnectToDatabaseUsingPortRM (hostName, port, _fbsDigestPassword ("_SYSTEM", databasePassword, digest), &localError);
 	FBCMetaData* session;
-	FBCErrorMetaData* errorMetaData;
 
 	if (connection == NULL) {
 		if (errorMessage != NULL) {
-			*errorMessage = localError;
+			*errorMessage = _fbsCopyError(localError);
 		}
 		return NULL;
 	}
@@ -107,9 +103,7 @@ FBSConnection fbsConnectDatabaseOnPort (const char* hostName,
 		return NULL;
 	} else if (fbcmdErrorsFound (session)) {
 		if (errorMessage != NULL) {
-			errorMetaData = fbcmdErrorMetaData (session);
-			*errorMessage = fbcemdAllErrorMessages (errorMetaData);
-			fbcemdRelease (errorMetaData);
+			*errorMessage = _fbsCopyAllMessages (session);
 		}
 
 		fbcmdRelease (session);
@@ -700,7 +694,7 @@ const char* fbsFetchMessage (FBSResult result) {
 /// The caller must free the returned string.
 /// The rationale for this function is this note from the meastro:
 ///   "You should always use fbcemdReleaseMessage on the result from fbcemdAllErrorMessages"
-static char *_fbsCopyAllMessages (FBCMetaData* metadata) {
+static char* _fbsCopyAllMessages (FBCMetaData* metadata) {
 	if (!fbcmdErrorsFound (metadata)) return NULL;
 
 	FBCErrorMetaData* emd = fbcmdErrorMetaData (metadata);

--- a/Sources/CFrontbaseSupport/include/Support.h
+++ b/Sources/CFrontbaseSupport/include/Support.h
@@ -61,7 +61,7 @@ FBSConnection _Nullable fbsConnectDatabaseOnHost (const char* databaseName,
                                                   const char* password,
                                                   const char* defaultSessionName,
                                                   const char* operatingSystemUser,
-                                                  const char* _Nullable * _Nullable errorMessage);
+                                                  char* _Nullable * _Nullable errorMessage);
 
 /// Open a connection at a port on a host, and create a session.
 /// Any returned FBSConnection MUST be deallocated using fbsCloseConnection().
@@ -73,7 +73,7 @@ FBSConnection _Nullable fbsConnectDatabaseOnPort (const char* hostName,
                                                   const char* password,
                                                   const char* defaultSessionName,
                                                   const char* operatingSystemUser,
-                                                  const char* _Nullable * _Nullable errorMessage);
+                                                  char* _Nullable * _Nullable errorMessage);
 
 /// Open a connection to a local database file, and create a session.
 /// Any returned FBSConnection MUST be deallocated using fbsClose().
@@ -85,7 +85,7 @@ FBSConnection _Nullable fbsConnectDatabaseAtPath (const char* databaseName,
                                                   const char* password,
                                                   const char* defaultSessionName,
                                                   const char* operatingSystemUser,
-                                                  const char* _Nullable * _Nullable errorMessage);
+                                                  char* _Nullable * _Nullable errorMessage);
 
 /// Close database connection, and deallocate data structures.
 void fbsCloseConnection (FBSConnection connection);
@@ -112,7 +112,7 @@ const char* fbsErrorMessage (FBSConnection connection);
 FBSResult _Nullable fbsExecuteSQL (FBSConnection connection,
                                    const char* sql,
                                    bool autoCommit,
-                                   const char* _Nullable * _Nullable errorMessage);
+                                   char* _Nullable * _Nullable errorMessage);
 
 /// Close result set, and deallocate data structures.
 void fbsCloseResult (FBSResult result);

--- a/Sources/FrontbaseNIO/FrontbaseStatement.swift
+++ b/Sources/FrontbaseNIO/FrontbaseStatement.swift
@@ -1,4 +1,5 @@
 import CFrontbaseSupport
+import Foundation
 
 internal class FrontbaseStatement {
     internal let connection: FrontbaseConnection
@@ -113,12 +114,11 @@ internal class FrontbaseStatement {
         guard connection.databaseConnection != nil else {
             throw FrontbaseError (reason: .error, message: "Connection has been closed")
         }
-        var errorMessage: UnsafePointer<Int8>? = nil
-        let resultSet: FBSResult? = withUnsafeMutablePointer (to: &errorMessage) { errorMessagePointer in
-            return fbsExecuteSQL (connection.databaseConnection!, sql + ";", connection.autoCommit, errorMessagePointer)
-        }
+        var errorMessage: UnsafeMutablePointer<Int8>? = nil
+        let resultSet: FBSResult? = fbsExecuteSQL (connection.databaseConnection!, sql + ";", connection.autoCommit, &errorMessage)
 
         if let message = errorMessage {
+            defer { free(message); errorMessage = nil }
             throw FrontbaseError (reason: .error, message: String (cString: message))
         }
 


### PR DESCRIPTION
Use `fbcdcConnectToURL()` when connecting to a file database as that functions allows a single process to open several concurrent connections to the same database.

Also ensure that the error messages returned from `fbsConnectDatabaseAtPath()` and `fbsExecuteSQL()` are proper copies of the FB error messages, so that callers can dispose of them with a normal call to `free()`.

This last point applies to other functions returning error messages too and will be addressed in a future commit. We'll also have to ensure that the error messages are freed on the Swift side I think.