### PR TITLE
FrontBase wants triple slash in file URLs

### DIFF
--- a/Sources/CFrontbaseSupport/Support.c
+++ b/Sources/CFrontbaseSupport/Support.c
@@ -149,7 +149,7 @@ FBSConnection fbsConnectDatabaseAtPath (const char* databaseName,
 	char digest[1000];
 	char url[1025];
 
-	int n = snprintf (url, 1025, "file://%s", filePath);
+	int n = snprintf (url, 1025, "file:///%s", filePath);
 	if (n >= 1025) {
 		if (errorMessage != NULL) {
 			*errorMessage = _fbsCopyError ("path too long");


### PR DESCRIPTION
With `file:///` as the base, appending `/tmp/mydb.fb` will result in a database at the path `/tmp/mydb.fb`, and appending `tmp/mydb.fb` will result in a database at `$PWD/tmp/mydb.fb`.